### PR TITLE
Add total column to the end of the table

### DIFF
--- a/app/javascript/components/Province.js
+++ b/app/javascript/components/Province.js
@@ -35,6 +35,7 @@ class Province extends React.Component {
               {this.props.municipalities.map(municipality => (
                 <th key={municipality.slug}>{ mun_count > 12 ? municipality.short_name : municipality.name }</th>
               ))}
+              <th>Totaal</th>
             </tr>
           </thead>
           <RegionDays days={ this.props.days } />
@@ -45,6 +46,7 @@ class Province extends React.Component {
               {this.props.municipalities.map(municipality => (
                 <Feed key={ municipality.slug } province={ this.props.province } municipality={ municipality } subscriptions={ this.state.subscriptions } onChange={ this.handleChange } />
               ))}
+              <td>Totaal</td>
             </tr>
           </tfoot>
         </table>

--- a/app/javascript/components/Provinces.js
+++ b/app/javascript/components/Provinces.js
@@ -16,6 +16,7 @@ class Provinces extends React.Component {
                   <a href={ `${ wave }/${ province.slug }` }>{ province.name }</a>
                 </th>
               ))}
+              <th>Totaal</th>
             </tr>
           </thead>
           <RegionDays days={ this.props.days } />
@@ -28,6 +29,7 @@ class Provinces extends React.Component {
                   <a href={ `${ wave }/${ province.slug }` }>{ province.name }</a>
                 </td>
               ))}
+              <td>Totaal</td>
             </tr>
           </tfoot>
         </table>

--- a/app/javascript/components/RegionDays.js
+++ b/app/javascript/components/RegionDays.js
@@ -5,6 +5,7 @@ import ReactDOM from 'react-dom'
 
 class RegionDays extends React.Component {
   transpose = m => m[0].map((x,i) => m.map(x => x[i]))
+  sum = (total, num) => total + num
 
   render () {
     return (
@@ -23,6 +24,9 @@ class RegionDays extends React.Component {
                 }
               </td>
             ))}
+            <td>
+              {day.cases.reduce(this.sum, 0)}
+            </td>
           </tr>
         ))}
       </tbody>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/123144/95621367-da996400-0a71-11eb-80ca-ca239656e83a.png)

I thought a total column would be useful at the end of the table. (I think **Totaal** is the right label.)

There is no color coding at the moment. I thought about doing a simple color coding to show if the totals of a day are greater (worse, so a reddish color), or less (better, so a greenish color) than the day before. I made a mock-up to see what it would look like.

![image](https://user-images.githubusercontent.com/123144/95621934-d1f55d80-0a72-11eb-9da7-1cca660244c2.png)


Please let me know what you think about this added column and the color coding idea. I can work on the color coding and make another commit (if you think it makes sense.)